### PR TITLE
Use the document root of the website

### DIFF
--- a/kirby-busted.php
+++ b/kirby-busted.php
@@ -2,7 +2,7 @@
 
 /**
  * KirbyBusted
- * Dead simple kirby asset busting. Assumes default kirby directory structure.
+ * Dead simple kirby asset busting.
  *
  * Example:
  * css(busted('assets/css/bundle.css'))
@@ -11,7 +11,7 @@
  */
 
 function busted ($path) {
-  $file = (__DIR__ . '/../../../' . $path);
+  $file = (kirby()->roots()->index() . DS . $path);
   return file_exists($file)
     ? $path . '?v=' . filemtime($file)
     : $path;


### PR DESCRIPTION
Instead of relying on the the default directory structure use the [document root of the website](https://getkirby.com/docs/cheatsheet/roots/index).